### PR TITLE
fix: centered search bar in app bar

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -23,6 +23,7 @@ const [open, setOpen] = useState(false);
   const StyledToolbar = styled(Toolbar)({
     display: "flex",
     justifyContent: "space-between",
+    position: "relative",
   });
   const Search = styled("div")(({ theme }) => ({
     backgroundColor: "white",
@@ -30,7 +31,7 @@ const [open, setOpen] = useState(false);
     gap:"5px",
     alignItems:"center",
     padding: "0 10px",
-    margin: "0px 20px",
+    
     borderRadius: theme.shape.borderRadius,
   }));
 
@@ -60,10 +61,14 @@ const [open, setOpen] = useState(false);
           LAMA DEV
         </Typography>
         <ResponsiveDrawer sx={{ display: { xs: "block", sm: "none", md: "none" } }} />
-        <Search>
-          <SearchIcon color="disabled"/>
-          <InputBase placeholder="Search.." ></InputBase>
-        </Search>
+
+        <Box sx={{ position: "absolute", left: "50%", transform: "translateX(-50%)" }}>
+          <Search>
+            <SearchIcon color="disabled" />
+            <InputBase placeholder="Search.." />
+          </Search>
+        </Box>
+        
         <Icons>
           <Badge badgeContent={2} color="error">
             <MailIcon />


### PR DESCRIPTION
This PR adjusts the alignment of the search bar in the AppBar to ensure that its middle is perfectly centered.

Changes Made:
✅ Added position: "relative" to StyledToolbar to allow absolute positioning inside.
✅ Removed margin: "0px 20px" from the Search component to prevent unnecessary shifting.
✅ Wrapped the Search component inside a Box with position: "absolute", left: "50%", and transform: "translateX(-50%)" to ensure exact centering.
